### PR TITLE
Format fix for metadata table

### DIFF
--- a/scripts/metadata_summarytsv.R
+++ b/scripts/metadata_summarytsv.R
@@ -102,7 +102,8 @@ results <- lapply(metadata_grouped, function(df) {
   #Extract unique counties where STATUS is NEW
   new_counties <- unique(na.omit(df %>%
                            filter(STATUS == "NEW") %>%
-                           select(SubmitterCounty)))
+                           select(SubmitterCounty))) %>%
+                           unlist()
   
   #Extract unique submitting facilities' names from Submitter facility
   all_names <- unique(na.omit(df$SubmitterName))
@@ -110,7 +111,8 @@ results <- lapply(metadata_grouped, function(df) {
   #Extract unique submitting facilities' names where STATUS is NEW
   new_names <- unique(na.omit(df %>%
                                    filter(STATUS == "NEW") %>%
-                                   select(SubmitterName)))
+                                   select(SubmitterName))) %>%
+                                   unlist()
   
   
   #Identify isolates from cases with the same DOB and extract their ID and WA_ID


### PR DESCRIPTION

## Description

Fixes metadata script outputting new counties/facilities in vector format

**Previous format:**

c("County 1", "County 2")

**Suggested format:**

County 1, County 2


## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Documentation update
-   [ ] Other (please specify)

## How to Test

Render report and check for format change in the New_Counties and New_Facilities columns in the metadata table.

## Checklist

-   [x] I have **reviewed** the pull request for any sensitive data, including text and images.
-   [x] I have read and followed the contributing guidelines.
-   [x] I have checked my code for any issues.
-   [ ] I have updated the documentation (if applicable).
-   [ ] I have added tests to cover my changes (if applicable).
-   [ ] All tests are passing (if applicable).
-   [x] My changes do not introduce any new warnings.
-   [x] I have run the code locally and verified the changes work as expected.
------------------------------------------------------------------------

By submitting this pull request, you agree that you have thoroughly reviewed the content and are confident that no sensitive data is exposed.
