### PR TITLE
Add mapping of sequencing ID to CASE ID

### DIFF
--- a/BacteriaGenomicsReports.qmd
+++ b/BacteriaGenomicsReports.qmd
@@ -28,8 +28,28 @@ source("scripts/metadata_summarytsv.R")
 
 ## Overview New Samples
 
-These are `r nrow(newseq)` new sequencing results in this BigBacter run.
+There are `r nrow(newseq)` new sequencing results in this BigBacter run.
 
+This is the mapping of the sequencing ID to the corresponding WDRS CASE_ID, if available
+```{r echo = FALSE}
+rdata_file <- file.path("metadata_summ", "mapping_case_ID.RData")
+
+load(rdata_file)
+
+#Table attributes
+kable(mapping_case_ID) %>%
+  kable_styling(
+    bootstrap_options = c("striped", "hover", "condensed", "responsive"),
+    full_width = FALSE,
+    position = "left",
+    font_size = 12,
+    html_font = "Arial"
+  ) %>%
+  row_spec(0, bold = TRUE)
+
+```
+
+The new isolates were classified by BigBacter as follows:
 ```{r echo = FALSE}
 outputs_script_dir <- "outputs_scripts"
 
@@ -42,7 +62,7 @@ summary_new_seq <- bind_rows(get(loaded_newseq[1]))
 #Table attributes
 kable(summary_new_seq) %>%
   kable_styling(
-    bootstrap_options = c("striped"),
+    bootstrap_options = c("striped", "hover", "condensed", "responsive"),
     full_width = FALSE,
     position = "left",
     font_size = 12,
@@ -52,7 +72,7 @@ kable(summary_new_seq) %>%
 
 ```
 
-Of these, the following isolates resulted in new genetic clusters.
+Of these, the following isolates resulted in new genetic clusters:
 
 ```{r echo = FALSE}
 #Identify samples that resulted in new clusters
@@ -63,7 +83,7 @@ new_clust<-newseq %>%
 if (nrow(new_clust) > 0) {
   kable(new_clust) %>%
   kable_styling(
-    bootstrap_options = c("striped"),
+    bootstrap_options = c("striped", "hover", "condensed", "responsive"),
     full_width = FALSE,
     position = "left",
     font_size = 12,
@@ -91,7 +111,7 @@ failed_df <- bind_rows(get(loaded_failed[1]))
 if (nrow(failed_df) > 0) {
   kable(failed_df) %>%
     kable_styling(
-      bootstrap_options = c("striped"),
+      bootstrap_options = c("striped", "hover", "condensed", "responsive"),
       full_width = FALSE,
       position = "left",
       font_size = 12,
@@ -123,7 +143,7 @@ summary_recomb <- bind_rows(get(loaded_summary_recomb[1]))
 if (nrow(summary_recomb) > 0) {
   kable(summary_recomb) %>%
     kable_styling(
-      bootstrap_options = c("striped"),
+      bootstrap_options = c("striped", "hover", "condensed", "responsive"),
       full_width = FALSE,
       position = "left",
       font_size = 12,
@@ -154,7 +174,7 @@ summary_snp <- bind_rows(get(loaded_snp_minmax[1]))
 if (nrow(summary_snp) > 0) {
   kable(summary_snp) %>%
     kable_styling(
-      bootstrap_options = c("striped"),
+      bootstrap_options = c("striped", "hover", "condensed", "responsive"),
       full_width = FALSE,
       position = "left",
       font_size = 12,
@@ -213,7 +233,7 @@ if (nrow(summary_snp_links) == 0) {
 
         cat(kable(filtered_links) %>%
           kable_styling(
-            bootstrap_options = c("striped"),
+            bootstrap_options = c("striped", "hover", "condensed", "responsive"),
             full_width = FALSE,
             position = "left",
             font_size = 12,
@@ -261,7 +281,7 @@ final_metadata <- bind_rows(all_data)
 #Table attributes
 kable(final_metadata) %>%
   kable_styling(
-    bootstrap_options = c("striped"),
+    bootstrap_options = c("striped", "hover", "condensed", "responsive"),
     full_width = FALSE,
     position = "left",
     font_size = 10,

--- a/BacteriaGenomicsReports.qmd
+++ b/BacteriaGenomicsReports.qmd
@@ -32,9 +32,9 @@ There are `r nrow(newseq)` new sequencing results in this BigBacter run.
 
 This is the mapping of the sequencing ID to the corresponding WDRS CASE_ID, if available
 ```{r echo = FALSE}
-rdata_file <- file.path("metadata_summ", "mapping_case_ID.RData")
+mapping_file <- file.path("outputs_scripts", "mapping_case_ID.RData")
 
-load(rdata_file)
+load(mapping_file)
 
 #Table attributes
 kable(mapping_case_ID) %>%

--- a/scripts/metadata_summarytsv.R
+++ b/scripts/metadata_summarytsv.R
@@ -1,7 +1,14 @@
 ##METADATA BY GENETIC CLUSTER
 #This script summarizes the metadata information by genetic cluster
 
-#Create a folder to save the metadata summaries
+#Create a folder to save the mapping of sequencing ID and WDRS Case ID
+outputs_script_dir <- "outputs_scripts"
+if (!dir.exists(outputs_script_dir)) {
+  dir.create(outputs_script_dir)
+}
+
+
+#Create a folder to save the metadata summaries for the metadata table
 results_dir <- "metadata_summ"
 if (!dir.exists(results_dir)) {
   dir.create(results_dir)
@@ -187,4 +194,4 @@ mapping_case_ID<-current_run_metadata%>%
          WA_ID,
          CASE_ID)
 
-save(mapping_case_ID, file = file.path(results_dir,"mapping_case_ID.RData"))
+save(mapping_case_ID, file = file.path(outputs_script_dir, "mapping_case_ID.RData"))

--- a/scripts/metadata_summarytsv.R
+++ b/scripts/metadata_summarytsv.R
@@ -177,3 +177,14 @@ for (name in names(metadata_grouped)) {
   
   save(combined_df, file = file.path(results_dir, paste0(output_name, ".RData")))
 }
+
+
+#Mapping of sequencing ID and CASE_ID
+mapping_case_ID<-current_run_metadata%>% 
+  filter(STATUS=="NEW") %>% 
+  mutate(CASE_ID=as.character(CASE_ID)) %>% 
+  select(ID,
+         WA_ID,
+         CASE_ID)
+
+save(mapping_case_ID, file = file.path(results_dir,"mapping_case_ID.RData"))


### PR DESCRIPTION
This is an enhancement to the report. The code added prints a table with the mapping of the sequencing ID to the Case ID. 
I have also included code to format all the tables as responsive when hovering over each row in the browser.

## Type of Change

-   [ ] Bug fix
-   [X] New feature
-   [ ] Documentation update
-   [ ] Other (please specify)

## How to Test

Render the changes in this branch using a different set of results other than the most recent Shigella run and check if the table prints correctly even when case ids are not available for some sequencing IDs. Case IDs were available for all sequences in the Shigella run used for development of the new table.

I validated the mapping by double checking the IDs and the corresponding Case IDs in the WDRS browser.

## Checklist

-   [X] I have **reviewed** the pull request for any sensitive data, including text and images.
-   [X] I have read and followed the contributing guidelines.
-   [X] I have checked my code for any issues.
-   [X] I have updated the documentation (if applicable).
-   [ ] I have added tests to cover my changes (if applicable).
-   [ ] All tests are passing (if applicable).
-   [X] My changes do not introduce any new warnings.
-   [X] I have run the code locally and verified the changes work as expected.
