### PR TITLE
Fix truncation of last ID

### DIFF
--- a/scripts/metadata_summarytsv.R
+++ b/scripts/metadata_summarytsv.R
@@ -163,13 +163,13 @@ results <- lapply(metadata_grouped, function(df) {
     group_by(PatientBirthDate) %>%
     filter(n() > 1 & !is.na(PatientBirthDate)) %>%
     select(ID, ID_ALT, PatientBirthDate)%>%
-    summarise(IDs = paste(ID, collapse = ", "), ID_ALT = paste(ID_ALT, collapse = ", "))
+    summarise(IDs = paste(ID, collapse = ","), ID_ALT = paste(ID_ALT, collapse = ","))
   
   #Format the duplicate DOB results
   if (nrow(same_dob) > 0) {
     duplicate_dob_str <- paste(
-      paste0("DOB: ",  same_dob$PatientBirthDate, " IDs: ",  same_dob$IDs),
-      collapse = paste0(";\n")
+      paste0(" [DOB: ",  same_dob$PatientBirthDate, " IDs: ",  same_dob$IDs),
+      collapse = "]"
     )
   } else {
     duplicate_dob_str <- "No isolates from the same case"
@@ -201,7 +201,7 @@ results <- lapply(metadata_grouped, function(df) {
   combined_df$New_IDs <- paste(new_IDs$ID,
                                new_IDs$ID_ALT,
                                collapse = "; ")
-  combined_df$Same_DOB_New_Isolates = duplicate_dob_str
+  combined_df$Same_DOB_Isolates = duplicate_dob_str
 
   
   return(combined_df)


### PR DESCRIPTION
## Description

This code prevents the truncation of the last ID when there are multiple DOBs and IDs getting displayed in the metadata table of the final HTML report

## Type of Change

-   [X] Bug fix
-   [ ] New feature
-   [ ] Documentation update
-   [ ] Other (please specify)

## How to Test

Render the HTML report with C. diphth data

## Checklist

-   [X] I have **reviewed** the pull request for any sensitive data, including text and images.
-   [X] I have read and followed the contributing guidelines.
-   [X] I have checked my code for any issues.
-   [ ] I have updated the documentation (if applicable).
-   [ ] I have added tests to cover my changes (if applicable).
-   [ ] All tests are passing (if applicable).
-   [X] My changes do not introduce any new warnings.
-   [X] I have run the code locally and verified the changes work as expected.

