### PR TITLE
Fixing partition info from getting duplicated

### DIFF
--- a/scripts/partition_info.R
+++ b/scripts/partition_info.R
@@ -33,7 +33,7 @@ if (length(snippy_file) > 0) {
   
   snippy_new_partition <- snippy_meta %>%
     filter(STATUS == "NEW") %>%
-    select(ID_clean, PARTITION) %>%
+    select(ID_clean, CLUSTER, PARTITION) %>%
     distinct()
   
   snippy_partition_counts <- snippy_meta %>%
@@ -47,7 +47,7 @@ if (length(snippy_file) > 0) {
   snippy_partition_info <- snippy_new_partition %>%
     rename(PARTITION_Snippy = PARTITION) %>%
     left_join(snippy_partition_counts,
-              by = c("PARTITION_Snippy" = "PARTITION"))
+              by = c("CLUSTER", "PARTITION_Snippy" = "PARTITION"))
   
 } else {
   
@@ -67,7 +67,7 @@ if (length(gubbins_file) > 0) {
   
   gubbins_new_partition <- gubbins_meta %>%
     filter(STATUS == "NEW") %>%
-    select(ID_clean, PARTITION) %>%
+    select(ID_clean, CLUSTER, PARTITION) %>%
     distinct()
   
   gubbins_partition_counts <- gubbins_meta %>%
@@ -81,7 +81,7 @@ if (length(gubbins_file) > 0) {
   gubbins_partition_info <- gubbins_new_partition %>%
     rename(PARTITION_Gubbins = PARTITION) %>%
     left_join(gubbins_partition_counts,
-              by = c("PARTITION_Gubbins" = "PARTITION"))
+              by = c("CLUSTER", "PARTITION_Gubbins" = "PARTITION"))
   
 } else {
   


### PR DESCRIPTION
## Description

When partition numbers are the same across clusters within the same taxa the table with the counts would show duplicate rows. I address this issue by modifying the left join in the script that counts the number of samples within each partition by joining not only on partition but also on cluster number.

Fixes #(issue)

## Type of Change

-   [X] Bug fix
-   [ ] New feature
-   [ ] Documentation update
-   [ ] Other (please specify)

## Checklist

-   [X] I have **reviewed** the pull request for any sensitive data, including text and images.
-   [X] I have read and followed the contributing guidelines.
-  [X] I have checked my code for any issues.
-  [X] I have updated the documentation (if applicable).
-  [X] I have added tests to cover my changes (if applicable).
- [X] All tests are passing (if applicable).
-  [X] My changes do not introduce any new warnings.
-  [X] I have run the code locally and verified the changes work as expected.


------------------------------------------------------------------------

By submitting this pull request, you agree that you have thoroughly reviewed the content and are confident that no sensitive data is exposed.
