### PR TITLE
Add healthcare facility origin name and params for HAI

### DIFF
--- a/BacteriaGenomicsReports.qmd
+++ b/BacteriaGenomicsReports.qmd
@@ -2,7 +2,7 @@
 title: "Bacterial Genomics - Summary Report"
 date: today
 author: 
-  - name: "Marcela Torres <br> Dahlia Walters <br> Shawn Hawken"
+  - name: "Marcela Torres <br> Dahlia Walters"
     affiliation: "Molecular Epidemiology Program, WA DOH"
 format: 
   html:
@@ -11,6 +11,7 @@ params:
   taxa: "Placeholder"
   phylogeny: "all" #defaults to showing both Snippy and Gubbins results but the rendering script will override this if Gubbins or Snippy are selected
   PatientAddressCounty: "all"  #defaults to showing all samples regardless of the patient address county
+  epiprogram: "na"  #defaults to not showing healthcare facility of origin name in the first metadata table if HAI is not specified
 ---
 
 ```{r, results='hide', echo=FALSE, message=FALSE, warning=FALSE}
@@ -67,6 +68,9 @@ PatientAddressCounty <- params$PatientAddressCounty
 PatientAddressCounty <- toTitleCase(tolower(PatientAddressCounty))
 ```
 
+```{r epidprogram, echo = FALSE}
+epiprogram <- params$epiprogram
+```
 
 
 ```{r global helper function, echo = FALSE}
@@ -130,7 +134,9 @@ summary_table_display <- summary_table_filtered  %>%
     "Collection Date" = SpecimenDateCollected,
     "Patient County" = PatientAddressCounty,
     "Submitter County" = SubmitterCounty,
-    "Submitter Facility" = SubmitterName
+    "Submitter Facility" = SubmitterName,
+    "Origin Facility" = OriginHealthFacility,
+    "Specimen Souce"=SpecimenSource
   )
 
 ```
@@ -141,6 +147,28 @@ In this BigBacter run, there are `r nrow(summary_table_filtered)` new sequencing
 
 This is a summary table which includes sample metadata and mapping of the sequencing ID to the corresponding WDRS CASE_ID, if available
 ```{r overview_new_samples_table, echo = FALSE}
+
+#Select columns based on epiprogram
+if (params$epiprogram == "HAI") {
+  summary_table_display<-summary_table_display %>% 
+    select("WA ID",
+    "ALT ID",
+    "WDRS ID",
+    "Collection Date",
+    "Patient County",
+    "Submitter County",
+    "Submitter Facility",
+    "Origin Facility")
+} else {
+   summary_table_display<-summary_table_display %>% 
+    select("WA ID",
+    "ALT ID",
+    "WDRS ID",
+    "Collection Date",
+    "Patient County",
+    "Submitter County")
+}
+  
 #Table attributes
 kable(summary_table_display) %>%
   kable_styling(

--- a/rendering_script.R
+++ b/rendering_script.R
@@ -25,6 +25,10 @@ phylogeny<- "all"
 #Enter the patient address county (data will be filtered by patient address county ex. King) or "all"
 PatientAddressCounty<- "all"   
 
+
+#Enter the epi program (if HAI is specified then healthcare facility origin name form the ARLN LIMS table will show in the metadata) or "na" for non-HAI epi programs
+epiprogram<- "na" 
+
 #Add date
 todays_date <- format(Sys.Date(), "%Y-%m-%d")
 
@@ -34,7 +38,8 @@ quarto_render(
   execute_params = list(
     taxa = taxa, 
     phylogeny = phylogeny,
-    PatientAddressCounty = PatientAddressCounty),
+    PatientAddressCounty = PatientAddressCounty,
+    epiprogram = epiprogram),
   output_file = paste0("BacteriaGenomicsReports_",  
                        PatientAddressCounty, "_", 
                        taxa, "_", 

--- a/scripts/metadata_summarytsv.R
+++ b/scripts/metadata_summarytsv.R
@@ -38,6 +38,7 @@ bacteriamastermeta_summ<-bacteriatrackerwa_meta_df %>%
   mutate(SpecimenDateCollected=as.Date(COLLECTION_DATE, format = "%Y-%m-%d")) %>%
   mutate(PatientBirthDate=as.Date(PatientBirthDate, format = "%Y-%m-%d")) %>% 
   mutate(WA_ID=ID)%>% 
+  mutate(OriginHealthFacility=Healthcare_facility_of_origin_name) %>% 
   select(WA_ID,
          ID_ALT,
          CASE_ID,
@@ -48,6 +49,7 @@ bacteriamastermeta_summ<-bacteriatrackerwa_meta_df %>%
          PatientAddressCounty,
          SubmitterCounty,
          SubmitterName,
+         OriginHealthFacility,
          SpecimenSource)
 
 # Left join WA IDs on ID
@@ -68,6 +70,7 @@ wa_joined <- wa_ids %>%
          PatientAddressCounty,
          SubmitterCounty,
          SubmitterName,
+         OriginHealthFacility,
          SpecimenSource)
 
 # Left join non-WA IDs on ID_ALT
@@ -90,6 +93,7 @@ non_wa_joined <- non_wa_ids %>%
          PatientAddressCounty,
          SubmitterCounty,
          SubmitterName,
+         OriginHealthFacility,
          SpecimenSource)
 
 # Append the two dataframes
@@ -248,7 +252,10 @@ summary_table<-current_run_metadata%>%
          SpecimenDateCollected,
          PatientAddressCounty,
          SubmitterCounty,
-         SubmitterName) %>% 
+         SubmitterName,
+         OriginHealthFacility,
+         SpecimenSource
+         ) %>% 
   distinct()
 
 #Remove row names


### PR DESCRIPTION
These changes add healthcare facility origin name and params for epi program. When HAI is specified in the epi program params the healthcare facility origin name is shown in the summary metadata table of the report.

The authors of the report is also updated to reflect the current members of the bacterial and mycotic unit.

## Type of Change

-New feature

## How to Test

Use the rendering script and enter epiprogram either HAI or na to specify the parameter

## Checklist

-   [X] I have **reviewed** the pull request for any sensitive data, including text and images.
-    [X] I have read and followed the contributing guidelines.
-    [X] I have checked my code for any issues.
-    [X] I have updated the documentation (if applicable).
-   [X] I have added tests to cover my changes (if applicable).
-    [X] All tests are passing (if applicable).
-    [X] My changes do not introduce any new warnings.
-    [X] I have run the code locally and verified the changes work as expected.


By submitting this pull request, you agree that you have thoroughly reviewed the content and are confident that no sensitive data is exposed.
